### PR TITLE
Change hover and selected colours in theme (#21)

### DIFF
--- a/crypto-tracker/src/App.js
+++ b/crypto-tracker/src/App.js
@@ -50,7 +50,7 @@ const theme = createTheme({
       // default: "#141416",
     },
     action: {
-      hover: colors.cyan[800],
+      hover: colors.blueGrey[700],
     },
     chip: {
       watch: colors.blueGrey[400],

--- a/crypto-tracker/src/components/layout/SidebarLink.jsx
+++ b/crypto-tracker/src/components/layout/SidebarLink.jsx
@@ -27,7 +27,7 @@ const SidebarLink = ({ text, Icon, route, toggleDrawer }) => {
               },
             },
             "&.Mui-selected": {
-              backgroundColor: "primary.dark",
+              backgroundColor: "secondary.dark",
               borderRadius: "10px",
             },
           }}


### PR DESCRIPTION
Resolves #21 

Hover colour changed in the theme to a lighter blue.
The selected page nav link is now cyan instead of a darker grey.